### PR TITLE
Internal rewrite of parse-duration to support CommonJS build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "jsonwebtoken": "^9.0.2",
         "moment": "^2.29.4",
         "opener": "^1.5.2",
-        "parse-duration": "^2.1.4",
         "patch-package": "^8.0.0",
         "plist": "^3.0.6",
         "progress": "^2.0.3",
@@ -1143,9 +1142,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3189,12 +3189,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/parse-duration": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-2.1.4.tgz",
-      "integrity": "sha512-b98m6MsCh+akxfyoz9w9dt0AlH2dfYLOBss5SdDsr9pkhKNvkWBXU/r8A4ahmIGByBOLV2+4YwfCuFxbDDaGyg==",
-      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "jsonwebtoken": "^9.0.2",
     "moment": "^2.29.4",
     "opener": "^1.5.2",
-    "parse-duration": "^2.1.4",
     "patch-package": "^8.0.0",
     "plist": "^3.0.6",
     "progress": "^2.0.3",

--- a/script/command-parser.ts
+++ b/script/command-parser.ts
@@ -5,7 +5,7 @@ import * as yargs from "yargs";
 import * as cli from "../script/types/cli";
 import * as chalk from "chalk";
 import backslash = require("backslash");
-import parseDuration from "parse-duration";
+import parseDuration from "./utils/parse-duration";
 
 const packageJson = require("../../package.json");
 const ROLLOUT_PERCENTAGE_REGEX: RegExp = /^(100|[1-9][0-9]|[1-9])%?$/;

--- a/script/utils/parse-duration.ts
+++ b/script/utils/parse-duration.ts
@@ -1,0 +1,45 @@
+const durationRE = /((?:\d{1,16}(?:\.\d{1,16})?|\.\d{1,16})(?:[eE][-+]?\d{1,4})?)\s?([\p{L}]{0,14})/gu
+
+const unit = Object.create(null)
+const m = 60000, h = m * 60, d = h * 24, y = d * 365.25
+
+unit.year = unit.yr = unit.y = y
+unit.month = unit.mo = unit.mth = y / 12
+unit.week = unit.wk = unit.w = d * 7
+unit.day = unit.d = d
+unit.hour = unit.hr = unit.h = h
+unit.minute = unit.min = unit.m = m
+unit.second = unit.sec = unit.s = 1000
+unit.millisecond = unit.millisec = unit.ms = 1
+unit.microsecond = unit.microsec =  unit.us = unit.µs = 1e-3
+unit.nanosecond = unit.nanosec = unit.ns = 1e-6
+
+unit.group = ','
+unit.decimal = '.'
+unit.placeholder = ' _'
+
+export default function parseDuration(str = '', format = 'ms') {
+  let result = null, prevUnits
+
+  String(str)
+    .replace(new RegExp(`(\\d)[${unit.placeholder}${unit.group}](\\d)`, 'g'), '$1$2')  // clean up group separators / placeholders
+    .replace(unit.decimal, '.') // normalize decimal separator
+    .replace(durationRE, (_, n, units) => {
+      // if no units, find next smallest units or fall back to format value
+      // eg. 1h30 -> 1h30m
+      if (!units) {
+        if (prevUnits) {
+          for (const u in unit) if (unit[u] < prevUnits) { units = u; break }
+        }
+        else units = format
+      }
+      else units = units.toLowerCase()
+
+      prevUnits = units = unit[units] || unit[units.replace(/s$/, '')]
+
+      if (units) result = (result || 0) + n * units
+      return result
+    })
+
+  return result && ((result / (unit[format] || 1)) * (str[0] === '-' ? -1 : 1))
+}


### PR DESCRIPTION
- `parse-duration`(>=2.0.0) ships only ESM bundles, breaking our CJS build.
- Downgrading is not an option due to a known CVE in earlier versions.
- This PR replaces it with a custom implementation that works in our CJS environment.

### To test:
```bash
npm install
npm run build
node bin/script/cli.js --version
```