### PR TITLE
fix: Support custom --outputDir with code signing

### DIFF
--- a/script/command-executor.ts
+++ b/script/command-executor.ts
@@ -217,7 +217,7 @@ function appRename(command: cli.IAppRenameCommand): Promise<void> {
 
 export const createEmptyTempReleaseFolder = (folderPath: string) => {
   return deleteFolder(folderPath).then(() => {
-    fs.mkdirSync(folderPath);
+    fs.mkdirSync(folderPath, { recursive: true });
   });
 };
 
@@ -1265,7 +1265,10 @@ export const release = (command: cli.IReleaseCommand): Promise<void> => {
 export const releaseReact = (command: cli.IReleaseReactCommand): Promise<void> => {
   let bundleName: string = command.bundleName;
   let entryFile: string = command.entryFile;
-  const outputFolder: string = command.outputDir || path.join(os.tmpdir(), "CodePush");
+  let outputFolder: string = command.outputDir || path.join(os.tmpdir(), "CodePush");
+  if (command.outputDir && path.basename(outputFolder) !== "CodePush") {
+    outputFolder = path.join(outputFolder, "CodePush");
+  }
   const platform: string = (command.platform = command.platform.toLowerCase());
   const releaseCommand: cli.IReleaseCommand = <any>command;
   // Check for app and deployment exist before releasing an update.


### PR DESCRIPTION
## Problem
  Using `--outputDir` with `--privateKeyPath` causes signature verification failures on the client.

  ## Root Cause
  The client SDK expects all files under a `CodePush/` directory in the update ZIP. Custom outputDir paths like `/tmp/CodePush-ios-49556` resulted in files being
  zipped as `CodePush-ios-49556/main.jsbundle` instead of `CodePush/main.jsbundle`, breaking signature verification.

  ## Solution
  - Automatically append `/CodePush` to custom outputDir paths to maintain correct ZIP structure
  - Use `recursive: true` when creating directories to support nested paths

  This is a general bug but it also enables features like parallel iOS/Android releases using different output directories while maintaining proper code signing.

  ## Testing
  - Verified with `--outputDir /tmp/CodePush-ios-12345 --privateKeyPath .codepush/private.pem`
  - Tested with and without `outputDor` flag
  - Signature verification now succeeds on client
  - ZIP structure correctly contains `CodePush/main.jsbundle` for both default and custom outputDir
